### PR TITLE
release/ens_tracker.v1.3.8 spa changes

### DIFF
--- a/ecf/jahgefs_tc_track.ecf
+++ b/ecf/jahgefs_tc_track.ecf
@@ -1,5 +1,5 @@
 #!/bin/bash
-#PBS -N ens_tracker_ahgefs_tc_%CYC%
+#PBS -N ens_tracker_ahgefs_tc_track_%CYC%
 #PBS -j oe
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
@@ -40,7 +40,7 @@ module load prod_util/$prod_util_ver
 module list
 
 # CALL executable job script here
-${PACKAGEHOME}/jobs/JAHGEFS_TC_TRACK
+${HOMEens_tracker}/jobs/JAHGEFS_TC_TRACK
 
 %include <tail.h>
 %manual

--- a/ecf/jaigefs_tc_track.ecf
+++ b/ecf/jaigefs_tc_track.ecf
@@ -1,10 +1,10 @@
 #!/bin/bash
-#PBS -N ens_tracker_aigefs_tc_%CYC%
+#PBS -N ens_tracker_aigefs_tc_track_%CYC%
 #PBS -j oe
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l place=vscatter,select=3:ncpus=31:mpiprocs=31:mem=100GB
+#PBS -l place=vscatter,select=3:ncpus=31:mpiprocs=31:mem=150GB
 #PBS -l walltime=00:25:00
 #PBS -l debug=true
 
@@ -40,7 +40,7 @@ module load prod_util/$prod_util_ver
 module list
 
 # CALL executable job script here
-${PACKAGEHOME}/jobs/JAIGEFS_TC_TRACK
+${HOMEens_tracker}/jobs/JAIGEFS_TC_TRACK
 
 %include <tail.h>
 %manual

--- a/ecf/jaigfs_tc_track.ecf
+++ b/ecf/jaigfs_tc_track.ecf
@@ -1,10 +1,10 @@
 #!/bin/bash
-#PBS -N ens_tracker_aigfs_tc_%CYC%
+#PBS -N ens_tracker_aigfs_tc_track_%CYC%
 #PBS -j oe
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=8GB
 #PBS -l walltime=00:10:00
 #PBS -l debug=true
 
@@ -40,7 +40,7 @@ module list
 
 
 # CALL executable job script here
-${PACKAGEHOME}/jobs/JAIGFS_TC_TRACK
+${HOMEens_tracker}/jobs/JAIGFS_TC_TRACK
 
 %include <tail.h> 
 %manual

--- a/ecf/jcens_tc_track.ecf
+++ b/ecf/jcens_tc_track.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l place=vscatter,select=3:ncpus=21:mpiprocs=21:mem=4GB
+#PBS -l place=vscatter,select=3:ncpus=21:mpiprocs=21:mem=32GB
 #PBS -l walltime=00:35:00
 #PBS -l debug=true
 

--- a/ecf/jcmc_tc_genesis.ecf
+++ b/ecf/jcmc_tc_genesis.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=8GB
 #PBS -l walltime=00:35:00
 #PBS -l debug=true
 

--- a/ecf/jcmc_tc_track.ecf
+++ b/ecf/jcmc_tc_track.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=16GB
 #PBS -l walltime=00:35:00
 #PBS -l debug=true
 

--- a/ecf/jecmwf_tc_genesis.ecf
+++ b/ecf/jecmwf_tc_genesis.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=8GB
 #PBS -l walltime=01:05:00
 #PBS -l debug=true
 

--- a/ecf/jecmwf_tc_track.ecf
+++ b/ecf/jecmwf_tc_track.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=16GB
 #PBS -l walltime=01:05:00
 #PBS -l debug=true
 

--- a/ecf/jeens_grib.ecf
+++ b/ecf/jeens_grib.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l place=vscatter,select=3:ncpus=41:mpiprocs=41:mem=40GB
+#PBS -l place=vscatter,select=3:ncpus=41:mpiprocs=41:mem=80GB
 #PBS -l walltime=01:15:00
 #PBS -l debug=true
 

--- a/ecf/jemy_tc_track.ecf
+++ b/ecf/jemy_tc_track.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=8GB
 #PBS -l walltime=01:05:00
 #PBS -l debug=true
 

--- a/ecf/jfens_tc_track.ecf
+++ b/ecf/jfens_tc_track.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l place=vscatter,select=3:ncpus=21:mpiprocs=21:mem=4GB
+#PBS -l place=vscatter,select=3:ncpus=21:mpiprocs=21:mem=8GB
 #PBS -l walltime=01:05:00
 #PBS -l debug=true
 

--- a/ecf/jgefs_tc_track.ecf
+++ b/ecf/jgefs_tc_track.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l place=vscatter,select=3:ncpus=31:mpiprocs=31:mem=100GB
+#PBS -l place=vscatter,select=3:ncpus=31:mpiprocs=31:mem=150GB
 #PBS -l walltime=00:25:00
 #PBS -l debug=true
 
@@ -39,7 +39,7 @@ module load prod_util/$prod_util_ver
 module list
 
 # CALL executable job script here
-${HOMEens_tracker}/jobs/JAIGEFS_TC_TRACK
+${HOMEens_tracker}/jobs/JGEFS_TC_TRACK
 
 %include <tail.h>
 %manual

--- a/ecf/jgfs_fsu_genesis.ecf
+++ b/ecf/jgfs_fsu_genesis.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=16GB
 #PBS -l walltime=00:10:00
 #PBS -l debug=true
 

--- a/ecf/jgfs_tc_genesis.ecf
+++ b/ecf/jgfs_tc_genesis.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=8GB
 #PBS -l walltime=00:25:00
 #PBS -l debug=true
 

--- a/ecf/jgfs_tc_track_avno.ecf
+++ b/ecf/jgfs_tc_track_avno.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=16GB
 #PBS -l walltime=00:10:00
 #PBS -l debug=true
 

--- a/ecf/jgfs_tc_track_avnx.ecf
+++ b/ecf/jgfs_tc_track_avnx.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=16GB
 #PBS -l walltime=00:10:00
 #PBS -l debug=true
 

--- a/ecf/jhgefs_tc_track.ecf
+++ b/ecf/jhgefs_tc_track.ecf
@@ -1,5 +1,5 @@
 #!/bin/bash
-#PBS -N ens_tracker_ahgefs_tc_track_%CYC%
+#PBS -N ens_tracker_hgefs_tc_track_%CYC%
 #PBS -j oe
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
@@ -40,7 +40,7 @@ module load prod_util/$prod_util_ver
 module list
 
 # CALL executable job script here
-${HOMEens_tracker}/jobs/JAHGEFS_TC_TRACK
+${HOMEens_tracker}/jobs/JHGEFS_TC_TRACK
 
 %include <tail.h>
 %manual

--- a/ecf/jukmet_tc_genesis.ecf
+++ b/ecf/jukmet_tc_genesis.ecf
@@ -4,7 +4,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=8GB
 #PBS -l walltime=00:30:00
 #PBS -l debug=true
 

--- a/jobs/JGFS_TC_GENESIS
+++ b/jobs/JGFS_TC_GENESIS
@@ -20,7 +20,7 @@ export cycle=t${cyc}z
 # Specify NET and RUN Name and model
 ####################################
 export NET=${NET:-ens_tracker}
-export RUN=${RUN:-gefs}
+export RUN=${RUN:-gfs}
 
 ####################################
 # Determine Job Output Name on System

--- a/jobs/JGFS_TC_TRACK_AVNX
+++ b/jobs/JGFS_TC_TRACK_AVNX
@@ -21,7 +21,7 @@ export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
 # Specify NET and RUN Name and model
 ####################################
 export NET=${NET:-ens_tracker}
-export RUN=${RUN:-gefs}
+export RUN=${RUN:-gfs}
 
 ####################################
 # Determine Job Output Name on System

--- a/jobs/JHGEFS_TC_TRACK
+++ b/jobs/JHGEFS_TC_TRACK
@@ -21,7 +21,7 @@ export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
 # Specify NET and RUN Name and model
 ####################################
 export NET=${NET:-ens_tracker}
-export RUN=${RUN:-ahgefs}
+export RUN=${RUN:-hgefs}
 
 ####################################
 # Determine Job Output Name on System
@@ -69,7 +69,7 @@ postmsg "$jlogfile" "$msg"
 
 #############################################################
 # Execute the script
-export cmodel=ahgefs
+export cmodel=hgefs
 export loopnum=1
 export ymdh=${PDY}${cyc}
 

--- a/parm/transfer_ens_tracker.list
+++ b/parm/transfer_ens_tracker.list
@@ -38,6 +38,21 @@ B 54000
 _COMROOT_/ens_tracker/_SHORTVER_/ecme._PDY_/
 B 54000
 
+_COMROOT_/ens_tracker/_SHORTVER_/aigfs._PDY_/
+B 54000
+
+_COMROOT_/ens_tracker/_SHORTVER_/aigefs._PDY_/
+B 54000
+
+_COMROOT_/ens_tracker/_SHORTVER_/aigefs._PDYm1_/
+B 54000
+
+_COMROOT_/ens_tracker/_SHORTVER_/ahgefs._PDY_/
+B 54000
+
+_COMROOT_/ens_tracker/_SHORTVER_/ahgefs._PDYm1_/
+B 54000
+
 _COMROOT_/ens_tracker/_SHORTVER_/ukmet._PDY_/
 B 54000
 

--- a/parm/transfer_ens_tracker.list
+++ b/parm/transfer_ens_tracker.list
@@ -47,10 +47,10 @@ B 54000
 _COMROOT_/ens_tracker/_SHORTVER_/aigefs._PDYm1_/
 B 54000
 
-_COMROOT_/ens_tracker/_SHORTVER_/ahgefs._PDY_/
+_COMROOT_/ens_tracker/_SHORTVER_/hgefs._PDY_/
 B 54000
 
-_COMROOT_/ens_tracker/_SHORTVER_/ahgefs._PDYm1_/
+_COMROOT_/ens_tracker/_SHORTVER_/hgefs._PDYm1_/
 B 54000
 
 _COMROOT_/ens_tracker/_SHORTVER_/ukmet._PDY_/

--- a/sorc/ens_trak_ave.fd/ens_trak_ave.f
+++ b/sorc/ens_trak_ave.fd/ens_trak_ave.f
@@ -892,7 +892,7 @@ cJ.Peng-04-15-2013
       select case (cmodel)
         case ('ens');  maxmem = ncmaxmem; fcsthrs(:) = ncfcsthrs(:)
         case ('aigefs'); maxmem = aimaxmem; fcsthrs(:) = aifcsthrs(:)
-        case ('ahgefs'); maxmem = ahmaxmem; fcsthrs(:) = ahfcsthrs(:)
+        case ('hgefs'); maxmem = ahmaxmem; fcsthrs(:) = ahfcsthrs(:)
         case ('ref');  maxmem = nrmaxmem; fcsthrs(:) = nrfcsthrs(:)
 
         case ('ensb');  maxmem = n0maxmem; fcsthrs(:) = n0fcsthrs(:)
@@ -982,7 +982,7 @@ cJ.Peng-04-15-2013
                        catcf    = 'AIMN'  
                        catcf_lc = 'aimn'
 
-        case ('ahgefs'); perts(:) = ahperts(:)
+        case ('hgefs'); perts(:) = ahperts(:)
                        minmem   = ahminmem  
                        catcf    = 'AHMN'  
                        catcf_lc = 'ahmn' 

--- a/ush/ens_trak_ave.sh
+++ b/ush/ens_trak_ave.sh
@@ -80,7 +80,7 @@ case ${cmodel} in
         amodel="aimn"                                          ;
         achar="a"                                              ;;
 
-  ahgefs) set +x; echo " "                                      ;
+  hgefs) set +x; echo " "                                      ;
         echo " ++ Input cmodel parameter = ${cmodel}...."      ;
         echo " ++ ML ensemble tracks will be averaged...."  ;
         echo " "; set -x                                       ;
@@ -137,7 +137,7 @@ echo "TIMING: Time before any of the track-averaging stuff is `date`"
 >trak.allperts.atcfunix.${amodel}.${ymdh}
 
 
-if [ ${cmodel} = 'ahgefs' ]; then
+if [ ${cmodel} = 'hgefs' ]; then
   set +f
   for dir in "${COMINgefs}" "${COMINaigefs}"; do
     for prefix in a ap ac mp mc; do

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -23,3 +23,5 @@ export gfs_ver=v16.3
 export gefs_ver=v12.3.1
 export ukmet_ver=v2.2
 
+export aigfs_ver=v1.0
+export aigefs_ver=v1.0


### PR DESCRIPTION
1. Adjusted PBS memory request (mem) upward in ecf scritps for jobs that were flagging "Cgroup: memory limit exceeded" in output files
2. Changed ${PACKAGEHOME} to ${HOMEens_tracker} in J-jobs
3. Changed $RUN from gefs to gfs in JGFS_TC_GENESIS and JGFS_TC_TRACK_AVNX (this is a legacy bug)
4. Updated transfers
5. Updated run.ver with aigfs_ver and aigefs_ver